### PR TITLE
Added information on how to fix the crashes on musl

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Ungoogled Chromium template and builds for Void Linux, based on the void-package
     - [Troubleshooting](#troubleshooting)
     - [Available builds](#available-builds)
     - [Installing the binary package](#installing-the-binary-package)
+- [Musl crashes mitigaton](#musl-crashes-mitigaton)
 - [Credits](#credits)
 
 ## Building from source
@@ -59,7 +60,7 @@ All packages are build using `void-packages` with `build_options="clang vaapi pu
 - In the past `gtk+3` was a runtime dependency for the package. On clean installs, it is required to install the `gtk+3` package manually.
 - i686 version fails to compile if `sndio` is enabled. Also breaks ungoogled-chromium patching. The patch is moved to the files directory and I have added a few checks to the template, so unless it is specified in `build_options` it won't be patched in.
 - To enable VAAPI edit `/usr/bin/ungoogled-chromium` and add `--enable-features=VaapiVideoDecoder` to `CHROME_FLAGS`. More info [here](//chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/vaapi.md). Also check [Void Handbook](//docs.voidlinux.org/config/graphical-session/graphics-drivers/intel.html) in case of problems.
-- As a warning, you might experience some stability issues on musl (tabs crashing with code 11 on javascript heavy sites). Most of the instability is caused by musl and has nothing to do with Chromium or the patches from Void or Ungoogled Chromium.
+- As a warning, you might experience some stability issues on musl (tabs crashing with code 11 on javascript heavy sites). Most of the instability is caused by musl and has nothing to do with Chromium or the patches from Void or Ungoogled Chromium. See [Musl crashes mitigaton](#musl-crashes-mitigaton)
 
 ### Available builds
 
@@ -75,6 +76,9 @@ Index and install the package:
     $ xbps-rindex -a *.xbps
     $ sudo xbps-install -vR $PWD ungoogled-chromium
     $ ungoogled-chromium
+
+## Musl crashes mitigaton
+If you experience frequent crashes on musl libc, add --js-flags=--jitless to chrome flags as a temporary fix.
 
 ## Credits
 


### PR DESCRIPTION
Today I installed voidlinux musl on my low-performance laptop, and I noticed that the number of crashes has increased. After a little experiment in the virtual machine I found that the number of crashes with code 11 is proportional to the CPU performance, after turning off JIT for an hour there was not a single crash ( previously opening reddit = instant crash )