### PR TITLE
102.0.5005.61

### DIFF
--- a/ungoogled-chromium/patches/xxx-ppc64le-4k-pages.patch
+++ b/ungoogled-chromium/patches/xxx-ppc64le-4k-pages.patch
@@ -9,6 +9,19 @@ Date:   Fri Jan 7 18:18:52 2022 +0100
     to wade through this pile of curse and we use 4k kernels anyway,
     assume 4K pages for ppc64
 
+diff --git a/base/allocator/partition_allocator/page_allocator_constants.h b/base/allocator/partition_allocator/page_allocator_constants.h
+index bfd5753..045082b 100644
+--- a/base/allocator/partition_allocator/page_allocator_constants.h
++++ b/base/allocator/partition_allocator/page_allocator_constants.h
+@@ -40,7 +40,7 @@ namespace base {
+
+ PAGE_ALLOCATOR_CONSTANTS_DECLARE_CONSTEXPR ALWAYS_INLINE size_t
+ PageAllocationGranularityShift() {
+-#if BUILDFLAG(IS_WIN) || defined(ARCH_CPU_PPC64)
++#if BUILDFLAG(IS_WIN)
+   // Modern ppc64 systems support 4kB (shift = 12) and 64kB (shift = 16) page
+   // sizes.  Since 64kB is the de facto standard on the platform and binaries
+   // compiled for 64kB are likely to work on 4kB systems, 64kB is a good choice
 diff --git a/base/allocator/partition_allocator/partition_alloc_constants.h b/base/allocator/partition_allocator/partition_alloc_constants.h
 index 0b9260d..3e054ec 100644
 --- a/base/allocator/partition_allocator/partition_alloc_constants.h

--- a/ungoogled-chromium/template
+++ b/ungoogled-chromium/template
@@ -11,7 +11,7 @@ homepage="https://github.com/Eloston/ungoogled-chromium"
 distfiles="https://commondatastorage.googleapis.com/chromium-browser-official/chromium-${version}.tar.xz
  ${homepage}/archive/refs/tags/${version}-${revision}.tar.gz"
 checksum="1a3797d36901fa3ba63744b9a870b65a8890c9a850442c160196bc64df886b1f
- 88a0f277fab63ab6aa673ac2a11c65e41624e6576f31a89f473c967997421ce5"
+ f93d69a7cf7a608e6b825dbfe33d7c92197e7caa730c94342e0c2c7e0483dacc"
 
 lib32disabled=yes
 


### PR DESCRIPTION
**Checklist**
- [x] Void template release ([Release](//github.com/void-linux/void-packages/tree/master/srcpkgs/chromium))
- [x] ungoogled-chromium release ([Release](//github.com/Eloston/ungoogled-chromium/releases))
- Build
	- [x] x86-64
	- [x] x86-64-musl
- add [1e1dcc0621a073a5c6a5b44acf6c8996c040d62b](https://github.com/void-linux/void-packages/commit/1e1dcc0621a073a5c6a5b44acf6c8996c040d62b)
- update to [102.0.5005.61-3](https://github.com/Eloston/ungoogled-chromium/releases/tag/102.0.5005.61-3)